### PR TITLE
fix: strip proposed vscode-dts references from positron.d.ts (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This table shows which version of Positron each package version was built agains
 
 | @posit-dev/positron | Positron Version | VS Code API | Notes |
 |---------------------|------------------|-------------|-------|
-| 0.2.4 | 2026.05.0+ |
+| 0.2.4 | 2026.05.0+ | 1.74.0+ | Strips proposed VS Code API references; fixes #4 |
 | 0.2.3 | 2026.04.0+ |
 | 0.2.2 | null+ |
 | 0.2.1 | null+ |

--- a/build.js
+++ b/build.js
@@ -157,6 +157,66 @@ try {
 }
 
 // =============================================================================
+// STEP 3.5: STRIP PROPOSED VSCODE-DTS REFERENCES FROM positron.d.ts
+// =============================================================================
+// positron.d.ts contains `/// <reference path="../vscode-dts/...">` directives
+// pointing at Positron-specific proposed VS Code API files. These files live in
+// the Positron monorepo and are not shipped with this package, so consumers hit
+// TS6053 ("file not found") errors (see issue #4).
+//
+// The types introduced by those proposed APIs are only used in a handful of
+// provider-facing signatures (positron.ai.LanguageModelChatProvider). Rather
+// than bundling the external files, we strip the reference directives and
+// replace the proposed types with `any` so the file is self-contained.
+
+console.log('\n📦 Step 3.5: Stripping proposed vscode-dts references from positron.d.ts...');
+
+const distPositronDts = path.join(PATHS.DIST_DIR, FILES.POSITRON_DTS);
+const vscDtsRefRegex = /^\/\/\/\s*<reference\s+path=["'][^"']*vscode-dts\/[^"']*["']\s*\/>\s*\n?/gm;
+
+const PROPOSED_TYPE_REPLACEMENTS = [
+	'LanguageModelChatInformation',
+	'ProvideLanguageModelChatResponseOptions',
+	'LanguageModelResponsePart2',
+	'LanguageModelChatMessage2',
+];
+
+try {
+	let content = fs.readFileSync(distPositronDts, 'utf8');
+
+	const refCount = (content.match(vscDtsRefRegex) || []).length;
+	if (refCount === 0) {
+		console.warn(
+			'   ⚠️  No vscode-dts reference directives found in dist/positron.d.ts; ' +
+			'if upstream removed them, Step 3.5 can be deleted'
+		);
+	}
+	content = content.replace(vscDtsRefRegex, '');
+
+	for (const typeName of PROPOSED_TYPE_REPLACEMENTS) {
+		const typeRegex = new RegExp(`vscode\\.${typeName}`, 'g');
+		content = content.replace(typeRegex, 'any');
+	}
+
+	// Clean up residual `X | any` unions and `extends any` constraints left
+	// by the naive find-and-replace so the output reads intentionally.
+	content = content.replace(/\w[\w.]*(?:\s*\|\s*\w[\w.]*)*\s*\|\s*any/g, 'any');
+	content = content.replace(/<T\s+extends\s+any\s*=\s*any>/g, '<T = any>');
+
+	const leftover = content.match(/vscode-dts\//g);
+	if (leftover) {
+		throw new Error(`Stripped references but ${leftover.length} vscode-dts path(s) remain`);
+	}
+
+	fs.writeFileSync(distPositronDts, content);
+	console.log(`   ✅ Removed ${refCount} vscode-dts reference directive(s)`);
+	console.log(`   ✅ Replaced ${PROPOSED_TYPE_REPLACEMENTS.length} proposed type(s) with \`any\``);
+} catch (error) {
+	console.error(`   ❌ Failed to strip vscode-dts references: ${error.message}`);
+	process.exit(1);
+}
+
+// =============================================================================
 // STEP 4: ADD REFERENCE DIRECTIVES TO MAIN DECLARATION FILE
 // =============================================================================
 // Modify the compiled index.d.ts file to include reference directives that

--- a/dist/positron.d.ts
+++ b/dist/positron.d.ts
@@ -1,10 +1,7 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-
-/// <reference path="../vscode-dts/vscode.proposed.chatProvider.d.ts" />
-/// <reference path="../vscode-dts/vscode.proposed.languageModelThinkingPart.d.ts" />
 
 declare module 'positron' {
 
@@ -229,6 +226,37 @@ declare module 'positron' {
 	}
 
 	/**
+	 * A position in a document using UTF-8 byte offsets.
+	 * This is used to losslessly communicate file or line offsets to backends.
+	 */
+	export interface Utf8Position {
+		/** 0-based line number */
+		readonly line: number;
+		/** 0-based column offset in UTF-8 bytes */
+		readonly character: number;
+	}
+
+	/**
+	 * A range in a document using UTF-8 byte offsets for character positions.
+	 */
+	export interface Utf8Range {
+		readonly start: Utf8Position;
+		readonly end: Utf8Position;
+	}
+
+	/**
+	 * A location in a document using UTF-8 byte offsets for character positions.
+	 *
+	 * This is a variant of vscode.Location where character offsets are in UTF-8 bytes
+	 * rather than UTF-16 code units. Use this when communicating with kernels that
+	 * need byte-based source positions.
+	 */
+	export interface Utf8Location {
+		readonly uri: vscode.Uri;
+		readonly range: Utf8Range;
+	}
+
+	/**
 	 * LanguageRuntimeExit is an interface that defines an event occurring when a
 	 * language runtime exits.
 	 */
@@ -277,6 +305,42 @@ declare module 'positron' {
 
 		/** Additional binary data, if any */
 		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * RuntimeResourceUsage represents resource usage information for a language runtime.
+	 */
+	export interface RuntimeResourceUsage {
+		/**
+		 * CPU usage percentage for the kernel and its children.
+		 */
+		cpu_percent: number;
+
+		/**
+		 * Memory usage in bytes for the kernel and its children.
+		 */
+		memory_bytes: number;
+
+		/**
+		 * Number of threads used by the kernel and its children.
+		 */
+		thread_count: number;
+
+		/**
+		 * Sampling period in milliseconds for the resource usage data.
+		 */
+		sampling_period_ms: number;
+
+		/**
+		 * Timestamp of the resource usage data in milliseconds since epoch.
+		 */
+		timestamp: number;
+
+		/**
+		 * The OS process ID of the kernel, if known. Used to avoid
+		 * double-counting kernel memory in the Positron process tree.
+		 */
+		process_id?: number;
 	}
 
 	/**
@@ -382,6 +446,19 @@ declare module 'positron' {
 		password: boolean;
 	}
 
+	/**
+	 * The CPU architecture of an interpreter.
+	 * Used to detect architecture mismatches between the interpreter and the system.
+	 */
+	export enum LanguageRuntimeArchitecture {
+		/** 64-bit ARM architecture (Apple Silicon, ARM64 Windows, etc.) */
+		Arm64 = 'arm64',
+		/** 64-bit x86 architecture (Intel/AMD) */
+		X64 = 'x64',
+		/** Architecture was detected but is not arm64 or x64 */
+		Other = 'other'
+	}
+
 	/** LanguageRuntimeInfo contains metadata about the runtime after it has started. */
 	export interface LanguageRuntimeInfo {
 		/** A startup banner */
@@ -401,6 +478,32 @@ declare module 'positron' {
 
 		/** Continuation prompt string in case user customized it */
 		continuation_prompt?: string;
+
+		/**
+		 * The interpreter's CPU architecture.
+		 * Used to detect architecture mismatches with the system.
+		 */
+		interpreterArch?: LanguageRuntimeArchitecture;
+	}
+
+	/**
+	 * Describes the kernel launch parameters used to start a runtime session.
+	 */
+	export interface LanguageRuntimeLaunchInfo {
+		/** The command line used to start the kernel */
+		argv: string[];
+
+		/** Environment variables set for the kernel process */
+		env: Record<string, string>;
+
+		/** Optional preflight command run before starting the kernel */
+		startupCommand?: string;
+
+		/** How the kernel handles interrupts */
+		interruptMode?: string;
+
+		/** The Jupyter protocol version in use */
+		protocolVersion?: string;
 	}
 
 	/** LanguageRuntimeState is a LanguageRuntimeMessage representing a new runtime state */
@@ -1034,6 +1137,109 @@ declare module 'positron' {
 		LSP = 'lsp',
 	}
 
+	export interface LanguageRuntimePackage {
+		id: string;
+		name: string;
+		displayName: string;
+		version: string;
+
+		/** License information */
+		license?: string;
+
+		/** Latest available version from repository */
+		latestVersion?: string;
+
+		/** Publication/release date */
+		publishedDate?: string;
+
+		/**
+		 * Whether the package is currently attached to the runtime's search
+		 * path (e.g. R's `search()`, Python's bound names in the user
+		 * namespace). Distinct from "loaded" in R parlance, where a package
+		 * can be loaded as a transitive dependency without being attached.
+		 */
+		attached?: boolean;
+	}
+
+	/**
+	 * Represents a package to install or update, with an optional version.
+	 */
+	export interface PackageSpec {
+		/** The package name */
+		name: string;
+		/** Optional version to install (if not specified, installs latest) */
+		version?: string;
+	}
+
+	/**
+	 * Interface for package management functionality.
+	 *
+	 * Provides package management operations for a language runtime session.
+	 * Runtimes that support package management should implement this interface
+	 * and return it from getPackageManager().
+	 */
+	export interface LanguageRuntimePackageManager {
+		/**
+		 * Get list of installed packages.
+		 * @param token Optional cancellation token
+		 */
+		getPackages(token?: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
+
+		/**
+		 * Install the list of packages.
+		 * @param packages Array of package install requests with name and optional version
+		 * @param token Optional cancellation token
+		 */
+		installPackages(packages: PackageSpec[], token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Uninstall the list of packages.
+		 * @param packageNames Array of package names to uninstall
+		 * @param token Optional cancellation token
+		 */
+		uninstallPackages(packageNames: string[], token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Update the list of packages.
+		 * @param packages Array of package install requests with name and optional version
+		 * @param token Optional cancellation token
+		 */
+		updatePackages(packages: PackageSpec[], token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Update all installed packages.
+		 * @param token Optional cancellation token
+		 */
+		updateAllPackages(token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Search a repository for packages matching the query.
+		 * @param query Search query string
+		 * @param token Optional cancellation token
+		 */
+		searchPackages(query: string, token?: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
+
+		/**
+		 * Search a repository for available versions of a package.
+		 * @param name Package name
+		 * @param token Optional cancellation token
+		 */
+		searchPackageVersions(name: string, token?: vscode.CancellationToken): Thenable<string[]>;
+
+		/**
+		 * Fetch additional metadata for packages from external sources (e.g., P3M).
+		 * This is called separately from getPackages() to allow the UI to display
+		 * the basic package list quickly while metadata loads in the background.
+		 * @param packageNames Array of package names to fetch metadata for
+		 * @param token Optional cancellation token
+		 * @returns Map of package name (lowercase) to partial package metadata
+		 */
+		getPackageMetadata?(
+			packageNames: string[],
+			token?: vscode.CancellationToken,
+		): Thenable<Map<string, Partial<LanguageRuntimePackage>>>;
+	}
+
 	/**
 	 * Basic metadata about an active language runtime session, including
 	 * immutable metadata about the session itself and metadata about the
@@ -1079,12 +1285,18 @@ declare module 'positron' {
 		 * @param id The ID of the code
 		 * @param mode The code execution mode
 		 * @param errorBehavior The code execution error behavior
+		 * @param codeLocation Optionally, the location of `code` in the source editor.
+		 * @param executionMetadata Optionally, a record of additional metadata to associate with this execution.
 		 * Note: The errorBehavior parameter is currently ignored by kernels
 		 */
-		execute(code: string,
+		execute(
+			code: string,
 			id: string,
 			mode: RuntimeCodeExecutionMode,
-			errorBehavior: RuntimeErrorBehavior): void;
+			errorBehavior: RuntimeErrorBehavior,
+			codeLocation?: Utf8Location,
+			executionMetadata?: Record<string, any>,
+		): void;
 
 		/**
 		 * Shut down the runtime; returns a Thenable that resolves when the
@@ -1112,6 +1324,9 @@ declare module 'positron' {
 
 		/** An object that emits an event when the user's session ends and the runtime exits */
 		onDidEndSession: vscode.Event<LanguageRuntimeExit>;
+
+		/** An object that emits an event when the runtime's resource usage is updated */
+		onDidUpdateResourceUsage: vscode.Event<RuntimeResourceUsage>;
 
 		/**
 		 * Opens a resource in the runtime.
@@ -1212,6 +1427,13 @@ declare module 'positron' {
 		updateSessionName(sessionName: string): void;
 
 		/**
+		 * Returns the kernel launch parameters used to start this session,
+		 * if available.
+		 */
+		getLaunchInfo?(): LanguageRuntimeLaunchInfo | undefined;
+
+
+		/**
 		 * Show runtime log in output panel.
 		 *
 		 * @param channel The channel to show the output in
@@ -1229,6 +1451,13 @@ declare module 'positron' {
 		 * Show profiler log if supported.
 		 */
 		showProfile?(): Thenable<void>;
+
+		/**
+		 * Get the package manager for this session, if available.
+		 *
+		 * Returns undefined if the runtime does not support package management.
+		 */
+		getPackageManager?(): LanguageRuntimePackageManager;
 	}
 
 
@@ -1420,6 +1649,9 @@ declare module 'positron' {
 		 * cursor is within. If the cursor is not within a statement, return the
 		 * range of the next statement, if one exists.
 		 *
+		 * Throw a {@link StatementRangeSyntaxError} to indicate that a statement range
+		 * cannot be provided due to a syntax error in the document.
+		 *
 		 * @param document The document in which the command was invoked.
 		 * @param position The position at which the command was invoked.
 		 * @param token A cancellation token.
@@ -1443,7 +1675,24 @@ declare module 'positron' {
 		 * The code for this statement range, if different from the document contents at this range.
 		 */
 		readonly code?: string;
+	}
 
+	/**
+	 * An error thrown by a {@link StatementRangeProvider} to indicate that a statement range
+	 * cannot be provided due to a syntax error in the document.
+	 */
+	export class StatementRangeSyntaxError extends Error {
+		/**
+		 * Zero indexed line number where the syntax error occurred.
+		 */
+		readonly line?: number;
+
+		/**
+		 * Creates a new statement range syntax error.
+		 *
+		 * @param line Zero indexed line number where the syntax error occurred.
+		 */
+		constructor(line?: number);
 	}
 
 	export interface HelpTopicProvider {
@@ -1508,8 +1757,15 @@ declare module 'positron' {
 		languageId: string;
 		/**
 		 * A human-readable name for the driver.
+		 * The name is also used to group drivers for the same database provider. For instance,
+		 * if there are multiple different ways to connect to the same database.
 		 */
 		name: string;
+		/**
+		 * A human-readable description for the driver.
+		 * Used specially when disambiguating drivers with the same name.
+		 */
+		description?: string;
 		/**
 		 * The base64-encoded SVG icon for the driver.
 		 */
@@ -1535,8 +1791,27 @@ declare module 'positron' {
 
 		/**
 		 * Generates the connection code based on the inputs.
+		 *
+		 * @param inputs The current values of the connection inputs defined in metadata.
+		 * @returns Either a string containing valid connection code, or an object with:
+		 *   - `code`: The generated connection code. Should still be generated even when
+		 *     validation fails, so users can see and copy the partial code.
+		 *   - `errorMessage`: A user-facing message explaining the validation error,
+		 *     displayed in an error banner overlay on the code editor. The Connect
+		 *     button is disabled when an error message is present.
+		 *
+		 * @example
+		 * // Return valid code as a string
+		 * generateCode: (inputs) => `library(DBI)\ncon <- dbConnect(...)`
+		 *
+		 * @example
+		 * // Return validation error with generated code
+		 * generateCode: (inputs) => ({
+		 *   code: `library(bigrquery)\ncon <- dbConnect(...)`,
+		 *   errorMessage: 'Project ID is required'
+		 * })
 		 */
-		generateCode?: (inputs: Array<ConnectionsInput>) => string;
+		generateCode?: (inputs: Array<ConnectionsInput>) => string | { code: string; errorMessage: string };
 
 		/**
 		 * Connect session.
@@ -1578,6 +1853,21 @@ declare module 'positron' {
 		Svg = 'svg',
 		Pdf = 'pdf',
 		Tiff = 'tiff'
+	}
+
+	/***
+	 * Represents the result of evaluating a code fragment in the runtime.
+	 */
+	export interface EvalResult {
+		/**
+		 * The value resulting from the code evaluation.
+		 */
+		result: any;
+
+		/**
+		 * The output emitted during code evaluation, if any.
+		 */
+		output: string;
 	}
 
 	namespace languages {
@@ -1651,7 +1941,7 @@ declare module 'positron' {
 		 *
 		 * @return New log output channel.
 		 */
-		export function createRawLogOutputChannel(name: string): vscode.OutputChannel;
+		export function createRawLogOutputChannel(name: string): vscode.LogOutputChannel;
 
 		/**
 		 * Create and show a simple modal dialog prompt.
@@ -1728,6 +2018,32 @@ declare module 'positron' {
 		 * plot widget.
 		 */
 		export function getPlotsRenderSettings(): Thenable<PlotRenderSettings>;
+
+	}
+
+	namespace context {
+		/**
+		 * Per-workspace ephemeral extension storage. Data survives extension
+		 * host restarts and window reloads, but does not persist beyond the
+		 * lifetime of the application process.
+		 *
+		 * Use this instead of {@link vscode.ExtensionContext.workspaceState workspaceState}
+		 * for state that is only meaningful while the process is running,
+		 * such as runtime session mappings. This avoids leaking stale
+		 * state on disk and ensures automatic cleanup on shutdown.
+		 */
+		export const ephemeralState: EphemeralMemento;
+
+		/**
+		 * A {@link vscode.Memento} with an additional `clear()` method that
+		 * removes all keys at once.
+		 */
+		export interface EphemeralMemento extends vscode.Memento {
+			/**
+			 * Remove all stored keys for this extension's ephemeral storage.
+			 */
+			clear(): Thenable<void>;
+		}
 	}
 
 	namespace runtime {
@@ -1834,6 +2150,11 @@ declare module 'positron' {
 		 *  not provided, an appropriate session will be chosen, and if no
 		 *  session for the desired language is running at all, a new session
 		 *  will be started.
+		 * @param documentUri An optional URI of the document in which the code to execute is located.
+		 * @param executionMetadata An optional object containing additional
+		 *  metadata to pass to the language runtime. Will be included in the
+		 *  `positron` field of the `metadata` argument passed to the runtime's
+		 *  `execute` method.
 		 * @returns A Thenable that resolves with the result of the code execution,
 		 *  as a map of MIME types to values.
 		 */
@@ -1844,7 +2165,43 @@ declare module 'positron' {
 			mode?: RuntimeCodeExecutionMode,
 			errorBehavior?: RuntimeErrorBehavior,
 			observer?: ExecutionObserver,
-			sessionId?: string): Thenable<Record<string, any>>;
+			sessionId?: string,
+			documentUri?: vscode.Uri,
+			executionMetadata?: Record<string, any>): Thenable<Record<string, any>>;
+
+		/**
+		 * Evaluates code silently in a language runtime, without displaying
+		 * output in the console or notifying the user.
+		 *
+		 * @param languageId The language ID of the code snippet
+		 * @param code The code snippet to evaluate
+		 * @param cancellationToken An optional cancellation token that can be
+		 *  used to cancel the evaluation.
+		 * @param sessionId An optional session ID to evaluate the code in. If
+		 *  not provided, an appropriate session will be chosen, and if no
+		 *  session for the desired language is running at all, a new session
+		 *  will be started.
+		 * @returns A Thenable that resolves with the result of the code
+		 *  evaluation.
+		 */
+		export function evaluateCode(languageId: string,
+			code: string,
+			cancellationToken?: vscode.CancellationToken,
+			sessionId?: string): Thenable<EvalResult>;
+
+		/**
+		 * Executes a set of cells in a source document. The results are
+		 * displayed beneath the cells.
+		 *
+		 * @param documentUri The URI of the document
+		 * @param range The ranges of the cells to execute
+		 * @param executionMetadata An optional array of metadata objects to
+		 *  pass to the language runtime, one for each cell being executed.
+		 */
+		export function executeInlineCell(documentUri: vscode.Uri,
+			cellRanges: vscode.Range[],
+			executionMetadata?: Record<string, any>[]
+		): Thenable<void>;
 
 		/**
 		 * Register a language runtime manager with Positron.
@@ -1915,11 +2272,24 @@ declare module 'positron' {
 			notebookUri?: vscode.Uri): Thenable<LanguageRuntimeSession>;
 
 		/**
+		 * Interrupt a running session.
+		 *
+		 * @param sessionId The ID of the session to interrupt.
+		 */
+		export function interruptSession(sessionId: string): Thenable<void>;
+
+		/**
 		 * Restart a running session.
 		 *
+		 * If the session is busy, the user is prompted whether to interrupt it
+		 * before restarting.
+		 *
 		 * @param sessionId The ID of the session to restart.
+		 * @returns `true` if the session was restarted (or a restart already in
+		 *   progress completed), `false` if the restart was declined by the user.
+		 *   Rejects if the session is not found or not in a restartable state.
 		 */
-		export function restartSession(sessionId: string): Thenable<void>;
+		export function restartSession(sessionId: string): Thenable<boolean>;
 
 		/**
 		 * Focus a running session.
@@ -1984,6 +2354,14 @@ declare module 'positron' {
 		export function registerClientInstance(clientInstanceId: string): vscode.Disposable;
 
 		/**
+		 * Emit a performance mark that can be used for telemetry and
+		 * performance monitoring. The mark is recorded at the current time.
+		 *
+		 * @param name The name of the performance mark.
+		 */
+		export function emitPerfMark(name: string): void;
+
+		/**
 		 * An event that fires when a new runtime is registered.
 		 */
 		export const onDidRegisterRuntime: vscode.Event<LanguageRuntimeMetadata>;
@@ -1997,6 +2375,52 @@ declare module 'positron' {
 		 * An event that fires when code is executed.
 		 */
 		export const onDidExecuteCode: vscode.Event<CodeExecutionEvent>;
+
+		/**
+		 * An item to be shown in the runtime picker quick pick.
+		 */
+		export interface RuntimePickerItem {
+			/** Unique identifier for this item */
+			id: string;
+			/** Label shown in the picker */
+			label: string;
+			/** Optional detail text shown below the label */
+			detail?: string;
+			/** Optional separator label to show before this item */
+			separatorLabel?: string;
+		}
+
+		/**
+		 * A contribution that adds items to the runtime picker.
+		 */
+		export interface RuntimePickerContribution {
+			/** The language ID this contribution applies to (e.g., 'python', 'r') */
+			languageId: string;
+
+			/**
+			 * Called when the runtime picker is about to be shown.
+			 * Return items to add to the picker, or an empty array if none should be shown.
+			 */
+			getItems(): Thenable<RuntimePickerItem[]>;
+
+			/**
+			 * Called when the user selects one of this contribution's items.
+			 * @param itemId The ID of the selected item
+			 * @returns The runtime ID to start, or undefined if no runtime should be started
+			 */
+			onDidSelectItem(itemId: string): Thenable<string | undefined>;
+		}
+
+		/**
+		 * Register a contribution that adds items to the runtime picker.
+		 * Extensions can use this to add custom actions like "Install Python via uv".
+		 *
+		 * @param contribution The contribution to register
+		 * @returns A disposable that unregisters the contribution when disposed
+		 */
+		export function registerRuntimePickerContribution(
+			contribution: RuntimePickerContribution
+		): vscode.Disposable;
 	}
 
 	// FIXME: The current (and clearly not final) state of an experiment to bring in interface(s)
@@ -2095,47 +2519,72 @@ declare module 'positron' {
 	}
 
 	/**
-	 * Utilities for pasting files as paths.
+	 * Utilities for formatting file paths for use in code.
 	 */
 	namespace paths {
 		/**
-		 * Options for extracting clipboard file paths
+		 * Specifies the base directory for making a relative path.
+		 * Can be an abstract reference (which will be made concrete at runtime)
+		 * or a literal URI.
+		 *
+		 * - 'workspace': The workspace folder
+		 * - 'session': Working directory of a session
+		 * - 'home': User's home directory
+		 * - vscode.Uri: A literal URI provided by the caller
 		 */
-		export interface ExtractClipboardFilePathsOptions {
+		export type RelativeBase = 'workspace' | 'session' | 'home' | vscode.Uri;
+
+		/**
+		 * Options for formatting file paths for use in code.
+		 */
+		export interface FormatPathForCodeOptions {
 			/**
-			 * Whether to prefer relative paths when workspace context is available.
-			 * Defaults to true.
+			 * Specifies base directories for relative path calculation, tried in order.
+			 * The path will be made relative to the first base that contains the file.
+			 * If omitted or empty, the path won't be relative-ized.
+			 *
+			 * Examples:
+			 * - ['workspace', 'home']: Try workspace-relative, fall back to home-relative
+			 * - ['session', 'home']: Try session-working-directory-relative, fall back to home-relative
+			 * - [vscode.Uri.file('/custom/base'), 'home']: Try custom base, fall back to home-relative
 			 */
-			preferRelative?: boolean;
+			relativeTo?: RelativeBase | RelativeBase[];
 
 			/**
-			 * Custom base URI for relative path calculation.
-			 * If not provided and preferRelative is true, uses the first workspace folder.
+			 * Optional session ID when using 'session' in relativeTo.
 			 */
-			baseUri?: vscode.Uri;
+			sessionId?: string;
 
 			/**
-			 * User home directory URI for home-relative path calculation.
+			 * User's home directory URI. Required for 'home' and to expand ~ in 'session'.
 			 */
 			homeUri?: vscode.Uri;
 		}
 
 		/**
-		 * Extract file paths from clipboard.
-		 * Detects files copied from file manager and returns their paths for use in scripts.
-		 * Windows: Replaces `\` with `/`.
-		 * Surrounds paths with double quotes (and escapes any internal double quotes).
-		 * Optionally returns relative paths (e.g. to workspace or user's home directory).
-		 * Try to use core utilities (versus DIY path hacking).
+		 * Format a file path for use in code.
+		 * - Replaces `\` with `/` because Windows.
+		 * - Surrounds path with double quotes and escapes any internal double quotes.
+		 * - Optionally returns a relative path (e.g. to workspace or user's home directory).
+		 *
+		 * @param filePath The file path to format
+		 * @param options Options for path formatting
+		 * @returns A Thenable that resolves to a quoted, forward-slash path ready for use in code,
+		 *  e.g., "C:/path/file.txt", "relative/path.txt", or "~/relative/path.txt"
+		 */
+		export function formatPathForCode(
+			filePath: string,
+			options?: FormatPathForCodeOptions
+		): Thenable<string>;
 
-		 * @param dataTransfer The clipboard data transfer object
-		 * @param options Options for path conversion
-		 * @returns A Thenable that resolves to an array of quoted, forward-slash,
-		 *  possibly relative file paths, or null if no files detected
+		/**
+		 * Extract file paths from clipboard data.
+		 * Detects files copied from a file manager and returns paths formatted for use in code,
+		 * or null if no files detected.
 		 */
 		export function extractClipboardFilePaths(
 			dataTransfer: vscode.DataTransfer,
-			options?: ExtractClipboardFilePathsOptions
+			options?: FormatPathForCodeOptions
 		): Thenable<string[] | null>;
 	}
 
@@ -2146,18 +2595,18 @@ declare module 'positron' {
 		/**
 		 * A language model provider, extends vscode.LanguageModelChatProvider.
 		 */
-		export interface LanguageModelChatProvider<T extends vscode.LanguageModelChatInformation = vscode.LanguageModelChatInformation> {
-			name: string;
-			provider: string;
+		export interface LanguageModelChatProvider<T = any> {
+			displayName: string;
+			providerId: string;
 			id: string;
 
 			providerName: string;
 
-			provideLanguageModelChatResponse(model: T, messages: Array<vscode.LanguageModelChatMessage>, options: vscode.ProvideLanguageModelChatResponseOptions, progress: vscode.Progress<vscode.LanguageModelResponsePart2>, token: vscode.CancellationToken): Thenable<any>;
+			provideLanguageModelChatResponse(model: T, messages: Array<vscode.LanguageModelChatMessage>, options: any, progress: vscode.Progress<any>, token: vscode.CancellationToken): Thenable<any>;
 
 			provideLanguageModelChatInformation(options: { silent: boolean }, token: vscode.CancellationToken): vscode.ProviderResult<T[]>;
 
-			provideTokenCount(model: T, text: string | vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2, token: vscode.CancellationToken): Thenable<number>;
+			provideTokenCount(model: T, text: any, token: vscode.CancellationToken): Thenable<number>;
 
 			/**
 			 * Tests the connection to the language model provider.
@@ -2173,7 +2622,7 @@ declare module 'positron' {
 			 * should be called before registering the chat provider.
 			 * @returns A list of supported model identifiers, or undefined if the provider does not support a model listing.
 			 */
-			resolveModels(token: vscode.CancellationToken): Thenable<vscode.LanguageModelChatInformation[] | undefined>;
+			resolveModels(token: vscode.CancellationToken): Thenable<any[] | undefined>;
 		}
 
 		/**
@@ -2210,11 +2659,34 @@ declare module 'positron' {
 		export function registerChatAgent(agentData: ChatAgentData): Thenable<vscode.Disposable>;
 
 		/**
+		 * Metadata about a language model provider used for configuration.
+		 * Registered during extension activation, independent of sign-in state.
+		 */
+		export interface ProviderMetadata {
+			/**
+			 * Unique identifier for this provider (e.g., 'anthropic-api', 'openai-api', 'copilot').
+			 * Used internally to distinguish between provider implementations.
+			 */
+			id: string;
+			/**
+			 * Display name shown in the UI (e.g., 'Anthropic', 'OpenAI', 'GitHub Copilot').
+			 * Appears in settings, model selection dialogs, and provider lists.
+			 */
+			displayName: string;
+			/**
+			 * Setting name for user configuration in camelCase format (e.g., 'anthropic', 'openAI', 'gitHubCopilot').
+			 * Corresponds to `positron.assistant.provider.<settingName>.enable` in settings.json if visible in Settings UI.
+			 * Positron's Assistant Service automatically reads this from registered providers.
+			 */
+			settingName: string;
+		}
+
+		/**
 		 * Positron Language Model source, used for user configuration of language models.
 		 */
 		export interface LanguageModelSource {
 			type: PositronLanguageModelType;
-			provider: { id: string; displayName: string };
+			provider: ProviderMetadata;
 			supportedOptions: Exclude<{
 				[K in keyof LanguageModelConfig]: undefined extends LanguageModelConfig[K] ? K : never
 			}[keyof LanguageModelConfig], undefined>[];
@@ -2304,12 +2776,21 @@ declare module 'positron' {
 			edits: vscode.TextEdit[];
 		}): void;
 
-		export function getSupportedProviders(): Thenable<string[]>;
-
 		/**
 		 * Get the chat export as a JSON object (IExportableChatData).
 		 */
 		export function getChatExport(): Thenable<object | undefined>;
+
+		/**
+		 * Options for showing the language model configuration modal.
+		 */
+		export interface ShowLanguageModelConfigOptions {
+			/**
+			 * Optional provider ID to pre-select in the dialog.
+			 * If provided and valid, the modal will open with this provider selected.
+			 */
+			preselectedProviderId?: string;
+		}
 
 		/**
 		 * Show a modal dialog for language model configuration.
@@ -2317,7 +2798,17 @@ declare module 'positron' {
 		export function showLanguageModelConfig(
 			sources: LanguageModelSource[],
 			onAction: (config: LanguageModelConfig, action: string) => Thenable<void>,
+			options?: ShowLanguageModelConfigOptions,
 		): Thenable<void>;
+
+		/**
+		 * Registers provider metadata with the core service.
+		 * This allows the core to check provider enable settings without requiring sign-in.
+		 * Should be called during extension activation for all available providers.
+		 *
+		 * @param metadata Provider identification and settings information
+		 */
+		export function registerProviderMetadata(metadata: ProviderMetadata): void;
 
 		/**
 		 * Adds the model to the service's known configurations and notifies its listeners.
@@ -2377,6 +2868,16 @@ declare module 'positron' {
 		export function setCurrentProvider(id: string): Thenable<ChatProvider | undefined>;
 
 		/**
+		 * Gets the list of enabled provider IDs from user configuration.
+		 *
+		 * Reads from individual provider enable settings ('positron.assistant.provider.<name>.enable')
+		 * and the deprecated 'positron.assistant.enabledProviders' array setting for backward compatibility.
+		 *
+		 * @returns A Thenable that resolves to an array of enabled provider IDs
+		 */
+		export function getEnabledProviders(): Thenable<string[]>;
+
+		/**
 		 * Checks if completions are enabled for the given file.
 		 * @param uri The file URI to check if completions are enabled.
 		 * @returns A Thenable that resolves to true if completions should be enabled for the file, false otherwise.
@@ -2422,6 +2923,12 @@ declare module 'positron' {
 			 * to fit without taking too much context.
 			 */
 			allCells?: NotebookCell[];
+
+			/**
+			 * The current state of the runtime session (e.g. 'idle', 'busy', 'restarting').
+			 * Undefined if no runtime session is associated with this notebook.
+			 */
+			runtimeState?: string;
 		}
 
 		/**
@@ -2500,10 +3007,10 @@ declare module 'positron' {
 			lastRunEndTime?: number;
 
 			/**
-			 * The cell document URI.
-			 * This is the URI that should be used for chat editing diffs.
+			 * For markdown cells only: whether the editor is shown (true) or preview is shown (false).
+			 * This property is undefined for code cells.
 			 */
-			cellUri: string;
+			editorShown?: boolean;
 		}
 
 		/**
@@ -2552,6 +3059,13 @@ declare module 'positron' {
 		export function deleteCell(notebookUri: string, cellIndex: number): Thenable<void>;
 
 		/**
+		 * Delete multiple cells from a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param cellIndices Array of cell indices to delete
+		 */
+		export function deleteCells(notebookUri: string, cellIndices: number[]): Thenable<void>;
+
+		/**
 		 * Update the content of a cell in a notebook
 		 * @param notebookUri URI of the notebook
 		 * @param cellIndex Index of the cell to update
@@ -2598,5 +3112,20 @@ declare module 'positron' {
 		 *                 Must be a valid permutation containing each index from 0 to cellCount-1 exactly once.
 		 */
 		export function reorderCells(notebookUri: string, newOrder: number[]): Thenable<void>;
+
+		/**
+		 * Scroll to a cell if it's out of view and auto-follow is enabled.
+		 * Respects the `positron.assistant.notebook.autoFollow` setting.
+		 * @param notebookUri The notebook URI as a string
+		 * @param cellIndex The index of the cell to scroll to
+		 */
+		export function scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Thenable<void>;
+
+		/**
+		 * Clear cell outputs in a notebook.
+		 * @param notebookUri URI of the notebook
+		 * @param cellIndices Optional array of cell indices to clear. If omitted, clears all cells.
+		 */
+		export function clearCellOutputs(notebookUri: string, cellIndices?: number[]): Thenable<void>;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.1",
-        "@types/vscode": "^1.100.0",
+        "@types/vscode": "^1.74.0",
         "@vitest/coverage-v8": "^3.2.3",
         "jsdom": "^26.1.0",
         "typescript": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.1",
-    "@types/vscode": "^1.100.0",
+    "@types/vscode": "^1.74.0",
     "@vitest/coverage-v8": "^3.2.3",
     "jsdom": "^26.1.0",
     "typescript": "^5.6.0",

--- a/src/positron.d.ts
+++ b/src/positron.d.ts
@@ -1,8 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/// <reference path="../vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts" />
+/// <reference path="../vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts" />
 /// <reference path="../vscode-dts/vscode.proposed.chatProvider.d.ts" />
 /// <reference path="../vscode-dts/vscode.proposed.languageModelThinkingPart.d.ts" />
 
@@ -229,6 +231,37 @@ declare module 'positron' {
 	}
 
 	/**
+	 * A position in a document using UTF-8 byte offsets.
+	 * This is used to losslessly communicate file or line offsets to backends.
+	 */
+	export interface Utf8Position {
+		/** 0-based line number */
+		readonly line: number;
+		/** 0-based column offset in UTF-8 bytes */
+		readonly character: number;
+	}
+
+	/**
+	 * A range in a document using UTF-8 byte offsets for character positions.
+	 */
+	export interface Utf8Range {
+		readonly start: Utf8Position;
+		readonly end: Utf8Position;
+	}
+
+	/**
+	 * A location in a document using UTF-8 byte offsets for character positions.
+	 *
+	 * This is a variant of vscode.Location where character offsets are in UTF-8 bytes
+	 * rather than UTF-16 code units. Use this when communicating with kernels that
+	 * need byte-based source positions.
+	 */
+	export interface Utf8Location {
+		readonly uri: vscode.Uri;
+		readonly range: Utf8Range;
+	}
+
+	/**
 	 * LanguageRuntimeExit is an interface that defines an event occurring when a
 	 * language runtime exits.
 	 */
@@ -277,6 +310,42 @@ declare module 'positron' {
 
 		/** Additional binary data, if any */
 		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * RuntimeResourceUsage represents resource usage information for a language runtime.
+	 */
+	export interface RuntimeResourceUsage {
+		/**
+		 * CPU usage percentage for the kernel and its children.
+		 */
+		cpu_percent: number;
+
+		/**
+		 * Memory usage in bytes for the kernel and its children.
+		 */
+		memory_bytes: number;
+
+		/**
+		 * Number of threads used by the kernel and its children.
+		 */
+		thread_count: number;
+
+		/**
+		 * Sampling period in milliseconds for the resource usage data.
+		 */
+		sampling_period_ms: number;
+
+		/**
+		 * Timestamp of the resource usage data in milliseconds since epoch.
+		 */
+		timestamp: number;
+
+		/**
+		 * The OS process ID of the kernel, if known. Used to avoid
+		 * double-counting kernel memory in the Positron process tree.
+		 */
+		process_id?: number;
 	}
 
 	/**
@@ -382,6 +451,19 @@ declare module 'positron' {
 		password: boolean;
 	}
 
+	/**
+	 * The CPU architecture of an interpreter.
+	 * Used to detect architecture mismatches between the interpreter and the system.
+	 */
+	export enum LanguageRuntimeArchitecture {
+		/** 64-bit ARM architecture (Apple Silicon, ARM64 Windows, etc.) */
+		Arm64 = 'arm64',
+		/** 64-bit x86 architecture (Intel/AMD) */
+		X64 = 'x64',
+		/** Architecture was detected but is not arm64 or x64 */
+		Other = 'other'
+	}
+
 	/** LanguageRuntimeInfo contains metadata about the runtime after it has started. */
 	export interface LanguageRuntimeInfo {
 		/** A startup banner */
@@ -401,6 +483,32 @@ declare module 'positron' {
 
 		/** Continuation prompt string in case user customized it */
 		continuation_prompt?: string;
+
+		/**
+		 * The interpreter's CPU architecture.
+		 * Used to detect architecture mismatches with the system.
+		 */
+		interpreterArch?: LanguageRuntimeArchitecture;
+	}
+
+	/**
+	 * Describes the kernel launch parameters used to start a runtime session.
+	 */
+	export interface LanguageRuntimeLaunchInfo {
+		/** The command line used to start the kernel */
+		argv: string[];
+
+		/** Environment variables set for the kernel process */
+		env: Record<string, string>;
+
+		/** Optional preflight command run before starting the kernel */
+		startupCommand?: string;
+
+		/** How the kernel handles interrupts */
+		interruptMode?: string;
+
+		/** The Jupyter protocol version in use */
+		protocolVersion?: string;
 	}
 
 	/** LanguageRuntimeState is a LanguageRuntimeMessage representing a new runtime state */
@@ -1034,6 +1142,109 @@ declare module 'positron' {
 		LSP = 'lsp',
 	}
 
+	export interface LanguageRuntimePackage {
+		id: string;
+		name: string;
+		displayName: string;
+		version: string;
+
+		/** License information */
+		license?: string;
+
+		/** Latest available version from repository */
+		latestVersion?: string;
+
+		/** Publication/release date */
+		publishedDate?: string;
+
+		/**
+		 * Whether the package is currently attached to the runtime's search
+		 * path (e.g. R's `search()`, Python's bound names in the user
+		 * namespace). Distinct from "loaded" in R parlance, where a package
+		 * can be loaded as a transitive dependency without being attached.
+		 */
+		attached?: boolean;
+	}
+
+	/**
+	 * Represents a package to install or update, with an optional version.
+	 */
+	export interface PackageSpec {
+		/** The package name */
+		name: string;
+		/** Optional version to install (if not specified, installs latest) */
+		version?: string;
+	}
+
+	/**
+	 * Interface for package management functionality.
+	 *
+	 * Provides package management operations for a language runtime session.
+	 * Runtimes that support package management should implement this interface
+	 * and return it from getPackageManager().
+	 */
+	export interface LanguageRuntimePackageManager {
+		/**
+		 * Get list of installed packages.
+		 * @param token Optional cancellation token
+		 */
+		getPackages(token?: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
+
+		/**
+		 * Install the list of packages.
+		 * @param packages Array of package install requests with name and optional version
+		 * @param token Optional cancellation token
+		 */
+		installPackages(packages: PackageSpec[], token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Uninstall the list of packages.
+		 * @param packageNames Array of package names to uninstall
+		 * @param token Optional cancellation token
+		 */
+		uninstallPackages(packageNames: string[], token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Update the list of packages.
+		 * @param packages Array of package install requests with name and optional version
+		 * @param token Optional cancellation token
+		 */
+		updatePackages(packages: PackageSpec[], token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Update all installed packages.
+		 * @param token Optional cancellation token
+		 */
+		updateAllPackages(token?: vscode.CancellationToken): Thenable<void>;
+
+		/**
+		 * Search a repository for packages matching the query.
+		 * @param query Search query string
+		 * @param token Optional cancellation token
+		 */
+		searchPackages(query: string, token?: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
+
+		/**
+		 * Search a repository for available versions of a package.
+		 * @param name Package name
+		 * @param token Optional cancellation token
+		 */
+		searchPackageVersions(name: string, token?: vscode.CancellationToken): Thenable<string[]>;
+
+		/**
+		 * Fetch additional metadata for packages from external sources (e.g., P3M).
+		 * This is called separately from getPackages() to allow the UI to display
+		 * the basic package list quickly while metadata loads in the background.
+		 * @param packageNames Array of package names to fetch metadata for
+		 * @param token Optional cancellation token
+		 * @returns Map of package name (lowercase) to partial package metadata
+		 */
+		getPackageMetadata?(
+			packageNames: string[],
+			token?: vscode.CancellationToken,
+		): Thenable<Map<string, Partial<LanguageRuntimePackage>>>;
+	}
+
 	/**
 	 * Basic metadata about an active language runtime session, including
 	 * immutable metadata about the session itself and metadata about the
@@ -1079,12 +1290,18 @@ declare module 'positron' {
 		 * @param id The ID of the code
 		 * @param mode The code execution mode
 		 * @param errorBehavior The code execution error behavior
+		 * @param codeLocation Optionally, the location of `code` in the source editor.
+		 * @param executionMetadata Optionally, a record of additional metadata to associate with this execution.
 		 * Note: The errorBehavior parameter is currently ignored by kernels
 		 */
-		execute(code: string,
+		execute(
+			code: string,
 			id: string,
 			mode: RuntimeCodeExecutionMode,
-			errorBehavior: RuntimeErrorBehavior): void;
+			errorBehavior: RuntimeErrorBehavior,
+			codeLocation?: Utf8Location,
+			executionMetadata?: Record<string, any>,
+		): void;
 
 		/**
 		 * Shut down the runtime; returns a Thenable that resolves when the
@@ -1112,6 +1329,9 @@ declare module 'positron' {
 
 		/** An object that emits an event when the user's session ends and the runtime exits */
 		onDidEndSession: vscode.Event<LanguageRuntimeExit>;
+
+		/** An object that emits an event when the runtime's resource usage is updated */
+		onDidUpdateResourceUsage: vscode.Event<RuntimeResourceUsage>;
 
 		/**
 		 * Opens a resource in the runtime.
@@ -1212,6 +1432,13 @@ declare module 'positron' {
 		updateSessionName(sessionName: string): void;
 
 		/**
+		 * Returns the kernel launch parameters used to start this session,
+		 * if available.
+		 */
+		getLaunchInfo?(): LanguageRuntimeLaunchInfo | undefined;
+
+
+		/**
 		 * Show runtime log in output panel.
 		 *
 		 * @param channel The channel to show the output in
@@ -1229,6 +1456,13 @@ declare module 'positron' {
 		 * Show profiler log if supported.
 		 */
 		showProfile?(): Thenable<void>;
+
+		/**
+		 * Get the package manager for this session, if available.
+		 *
+		 * Returns undefined if the runtime does not support package management.
+		 */
+		getPackageManager?(): LanguageRuntimePackageManager;
 	}
 
 
@@ -1420,6 +1654,9 @@ declare module 'positron' {
 		 * cursor is within. If the cursor is not within a statement, return the
 		 * range of the next statement, if one exists.
 		 *
+		 * Throw a {@link StatementRangeSyntaxError} to indicate that a statement range
+		 * cannot be provided due to a syntax error in the document.
+		 *
 		 * @param document The document in which the command was invoked.
 		 * @param position The position at which the command was invoked.
 		 * @param token A cancellation token.
@@ -1443,7 +1680,24 @@ declare module 'positron' {
 		 * The code for this statement range, if different from the document contents at this range.
 		 */
 		readonly code?: string;
+	}
 
+	/**
+	 * An error thrown by a {@link StatementRangeProvider} to indicate that a statement range
+	 * cannot be provided due to a syntax error in the document.
+	 */
+	export class StatementRangeSyntaxError extends Error {
+		/**
+		 * Zero indexed line number where the syntax error occurred.
+		 */
+		readonly line?: number;
+
+		/**
+		 * Creates a new statement range syntax error.
+		 *
+		 * @param line Zero indexed line number where the syntax error occurred.
+		 */
+		constructor(line?: number);
 	}
 
 	export interface HelpTopicProvider {
@@ -1508,8 +1762,15 @@ declare module 'positron' {
 		languageId: string;
 		/**
 		 * A human-readable name for the driver.
+		 * The name is also used to group drivers for the same database provider. For instance,
+		 * if there are multiple different ways to connect to the same database.
 		 */
 		name: string;
+		/**
+		 * A human-readable description for the driver.
+		 * Used specially when disambiguating drivers with the same name.
+		 */
+		description?: string;
 		/**
 		 * The base64-encoded SVG icon for the driver.
 		 */
@@ -1535,8 +1796,27 @@ declare module 'positron' {
 
 		/**
 		 * Generates the connection code based on the inputs.
+		 *
+		 * @param inputs The current values of the connection inputs defined in metadata.
+		 * @returns Either a string containing valid connection code, or an object with:
+		 *   - `code`: The generated connection code. Should still be generated even when
+		 *     validation fails, so users can see and copy the partial code.
+		 *   - `errorMessage`: A user-facing message explaining the validation error,
+		 *     displayed in an error banner overlay on the code editor. The Connect
+		 *     button is disabled when an error message is present.
+		 *
+		 * @example
+		 * // Return valid code as a string
+		 * generateCode: (inputs) => `library(DBI)\ncon <- dbConnect(...)`
+		 *
+		 * @example
+		 * // Return validation error with generated code
+		 * generateCode: (inputs) => ({
+		 *   code: `library(bigrquery)\ncon <- dbConnect(...)`,
+		 *   errorMessage: 'Project ID is required'
+		 * })
 		 */
-		generateCode?: (inputs: Array<ConnectionsInput>) => string;
+		generateCode?: (inputs: Array<ConnectionsInput>) => string | { code: string; errorMessage: string };
 
 		/**
 		 * Connect session.
@@ -1578,6 +1858,21 @@ declare module 'positron' {
 		Svg = 'svg',
 		Pdf = 'pdf',
 		Tiff = 'tiff'
+	}
+
+	/***
+	 * Represents the result of evaluating a code fragment in the runtime.
+	 */
+	export interface EvalResult {
+		/**
+		 * The value resulting from the code evaluation.
+		 */
+		result: any;
+
+		/**
+		 * The output emitted during code evaluation, if any.
+		 */
+		output: string;
 	}
 
 	namespace languages {
@@ -1651,7 +1946,7 @@ declare module 'positron' {
 		 *
 		 * @return New log output channel.
 		 */
-		export function createRawLogOutputChannel(name: string): vscode.OutputChannel;
+		export function createRawLogOutputChannel(name: string): vscode.LogOutputChannel;
 
 		/**
 		 * Create and show a simple modal dialog prompt.
@@ -1728,6 +2023,32 @@ declare module 'positron' {
 		 * plot widget.
 		 */
 		export function getPlotsRenderSettings(): Thenable<PlotRenderSettings>;
+
+	}
+
+	namespace context {
+		/**
+		 * Per-workspace ephemeral extension storage. Data survives extension
+		 * host restarts and window reloads, but does not persist beyond the
+		 * lifetime of the application process.
+		 *
+		 * Use this instead of {@link vscode.ExtensionContext.workspaceState workspaceState}
+		 * for state that is only meaningful while the process is running,
+		 * such as runtime session mappings. This avoids leaking stale
+		 * state on disk and ensures automatic cleanup on shutdown.
+		 */
+		export const ephemeralState: EphemeralMemento;
+
+		/**
+		 * A {@link vscode.Memento} with an additional `clear()` method that
+		 * removes all keys at once.
+		 */
+		export interface EphemeralMemento extends vscode.Memento {
+			/**
+			 * Remove all stored keys for this extension's ephemeral storage.
+			 */
+			clear(): Thenable<void>;
+		}
 	}
 
 	namespace runtime {
@@ -1834,6 +2155,11 @@ declare module 'positron' {
 		 *  not provided, an appropriate session will be chosen, and if no
 		 *  session for the desired language is running at all, a new session
 		 *  will be started.
+		 * @param documentUri An optional URI of the document in which the code to execute is located.
+		 * @param executionMetadata An optional object containing additional
+		 *  metadata to pass to the language runtime. Will be included in the
+		 *  `positron` field of the `metadata` argument passed to the runtime's
+		 *  `execute` method.
 		 * @returns A Thenable that resolves with the result of the code execution,
 		 *  as a map of MIME types to values.
 		 */
@@ -1844,7 +2170,43 @@ declare module 'positron' {
 			mode?: RuntimeCodeExecutionMode,
 			errorBehavior?: RuntimeErrorBehavior,
 			observer?: ExecutionObserver,
-			sessionId?: string): Thenable<Record<string, any>>;
+			sessionId?: string,
+			documentUri?: vscode.Uri,
+			executionMetadata?: Record<string, any>): Thenable<Record<string, any>>;
+
+		/**
+		 * Evaluates code silently in a language runtime, without displaying
+		 * output in the console or notifying the user.
+		 *
+		 * @param languageId The language ID of the code snippet
+		 * @param code The code snippet to evaluate
+		 * @param cancellationToken An optional cancellation token that can be
+		 *  used to cancel the evaluation.
+		 * @param sessionId An optional session ID to evaluate the code in. If
+		 *  not provided, an appropriate session will be chosen, and if no
+		 *  session for the desired language is running at all, a new session
+		 *  will be started.
+		 * @returns A Thenable that resolves with the result of the code
+		 *  evaluation.
+		 */
+		export function evaluateCode(languageId: string,
+			code: string,
+			cancellationToken?: vscode.CancellationToken,
+			sessionId?: string): Thenable<EvalResult>;
+
+		/**
+		 * Executes a set of cells in a source document. The results are
+		 * displayed beneath the cells.
+		 *
+		 * @param documentUri The URI of the document
+		 * @param range The ranges of the cells to execute
+		 * @param executionMetadata An optional array of metadata objects to
+		 *  pass to the language runtime, one for each cell being executed.
+		 */
+		export function executeInlineCell(documentUri: vscode.Uri,
+			cellRanges: vscode.Range[],
+			executionMetadata?: Record<string, any>[]
+		): Thenable<void>;
 
 		/**
 		 * Register a language runtime manager with Positron.
@@ -1915,11 +2277,24 @@ declare module 'positron' {
 			notebookUri?: vscode.Uri): Thenable<LanguageRuntimeSession>;
 
 		/**
+		 * Interrupt a running session.
+		 *
+		 * @param sessionId The ID of the session to interrupt.
+		 */
+		export function interruptSession(sessionId: string): Thenable<void>;
+
+		/**
 		 * Restart a running session.
 		 *
+		 * If the session is busy, the user is prompted whether to interrupt it
+		 * before restarting.
+		 *
 		 * @param sessionId The ID of the session to restart.
+		 * @returns `true` if the session was restarted (or a restart already in
+		 *   progress completed), `false` if the restart was declined by the user.
+		 *   Rejects if the session is not found or not in a restartable state.
 		 */
-		export function restartSession(sessionId: string): Thenable<void>;
+		export function restartSession(sessionId: string): Thenable<boolean>;
 
 		/**
 		 * Focus a running session.
@@ -1984,6 +2359,14 @@ declare module 'positron' {
 		export function registerClientInstance(clientInstanceId: string): vscode.Disposable;
 
 		/**
+		 * Emit a performance mark that can be used for telemetry and
+		 * performance monitoring. The mark is recorded at the current time.
+		 *
+		 * @param name The name of the performance mark.
+		 */
+		export function emitPerfMark(name: string): void;
+
+		/**
 		 * An event that fires when a new runtime is registered.
 		 */
 		export const onDidRegisterRuntime: vscode.Event<LanguageRuntimeMetadata>;
@@ -1997,6 +2380,52 @@ declare module 'positron' {
 		 * An event that fires when code is executed.
 		 */
 		export const onDidExecuteCode: vscode.Event<CodeExecutionEvent>;
+
+		/**
+		 * An item to be shown in the runtime picker quick pick.
+		 */
+		export interface RuntimePickerItem {
+			/** Unique identifier for this item */
+			id: string;
+			/** Label shown in the picker */
+			label: string;
+			/** Optional detail text shown below the label */
+			detail?: string;
+			/** Optional separator label to show before this item */
+			separatorLabel?: string;
+		}
+
+		/**
+		 * A contribution that adds items to the runtime picker.
+		 */
+		export interface RuntimePickerContribution {
+			/** The language ID this contribution applies to (e.g., 'python', 'r') */
+			languageId: string;
+
+			/**
+			 * Called when the runtime picker is about to be shown.
+			 * Return items to add to the picker, or an empty array if none should be shown.
+			 */
+			getItems(): Thenable<RuntimePickerItem[]>;
+
+			/**
+			 * Called when the user selects one of this contribution's items.
+			 * @param itemId The ID of the selected item
+			 * @returns The runtime ID to start, or undefined if no runtime should be started
+			 */
+			onDidSelectItem(itemId: string): Thenable<string | undefined>;
+		}
+
+		/**
+		 * Register a contribution that adds items to the runtime picker.
+		 * Extensions can use this to add custom actions like "Install Python via uv".
+		 *
+		 * @param contribution The contribution to register
+		 * @returns A disposable that unregisters the contribution when disposed
+		 */
+		export function registerRuntimePickerContribution(
+			contribution: RuntimePickerContribution
+		): vscode.Disposable;
 	}
 
 	// FIXME: The current (and clearly not final) state of an experiment to bring in interface(s)
@@ -2095,47 +2524,72 @@ declare module 'positron' {
 	}
 
 	/**
-	 * Utilities for pasting files as paths.
+	 * Utilities for formatting file paths for use in code.
 	 */
 	namespace paths {
 		/**
-		 * Options for extracting clipboard file paths
+		 * Specifies the base directory for making a relative path.
+		 * Can be an abstract reference (which will be made concrete at runtime)
+		 * or a literal URI.
+		 *
+		 * - 'workspace': The workspace folder
+		 * - 'session': Working directory of a session
+		 * - 'home': User's home directory
+		 * - vscode.Uri: A literal URI provided by the caller
 		 */
-		export interface ExtractClipboardFilePathsOptions {
+		export type RelativeBase = 'workspace' | 'session' | 'home' | vscode.Uri;
+
+		/**
+		 * Options for formatting file paths for use in code.
+		 */
+		export interface FormatPathForCodeOptions {
 			/**
-			 * Whether to prefer relative paths when workspace context is available.
-			 * Defaults to true.
+			 * Specifies base directories for relative path calculation, tried in order.
+			 * The path will be made relative to the first base that contains the file.
+			 * If omitted or empty, the path won't be relative-ized.
+			 *
+			 * Examples:
+			 * - ['workspace', 'home']: Try workspace-relative, fall back to home-relative
+			 * - ['session', 'home']: Try session-working-directory-relative, fall back to home-relative
+			 * - [vscode.Uri.file('/custom/base'), 'home']: Try custom base, fall back to home-relative
 			 */
-			preferRelative?: boolean;
+			relativeTo?: RelativeBase | RelativeBase[];
 
 			/**
-			 * Custom base URI for relative path calculation.
-			 * If not provided and preferRelative is true, uses the first workspace folder.
+			 * Optional session ID when using 'session' in relativeTo.
 			 */
-			baseUri?: vscode.Uri;
+			sessionId?: string;
 
 			/**
-			 * User home directory URI for home-relative path calculation.
+			 * User's home directory URI. Required for 'home' and to expand ~ in 'session'.
 			 */
 			homeUri?: vscode.Uri;
 		}
 
 		/**
-		 * Extract file paths from clipboard.
-		 * Detects files copied from file manager and returns their paths for use in scripts.
-		 * Windows: Replaces `\` with `/`.
-		 * Surrounds paths with double quotes (and escapes any internal double quotes).
-		 * Optionally returns relative paths (e.g. to workspace or user's home directory).
-		 * Try to use core utilities (versus DIY path hacking).
+		 * Format a file path for use in code.
+		 * - Replaces `\` with `/` because Windows.
+		 * - Surrounds path with double quotes and escapes any internal double quotes.
+		 * - Optionally returns a relative path (e.g. to workspace or user's home directory).
+		 *
+		 * @param filePath The file path to format
+		 * @param options Options for path formatting
+		 * @returns A Thenable that resolves to a quoted, forward-slash path ready for use in code,
+		 *  e.g., "C:/path/file.txt", "relative/path.txt", or "~/relative/path.txt"
+		 */
+		export function formatPathForCode(
+			filePath: string,
+			options?: FormatPathForCodeOptions
+		): Thenable<string>;
 
-		 * @param dataTransfer The clipboard data transfer object
-		 * @param options Options for path conversion
-		 * @returns A Thenable that resolves to an array of quoted, forward-slash,
-		 *  possibly relative file paths, or null if no files detected
+		/**
+		 * Extract file paths from clipboard data.
+		 * Detects files copied from a file manager and returns paths formatted for use in code,
+		 * or null if no files detected.
 		 */
 		export function extractClipboardFilePaths(
 			dataTransfer: vscode.DataTransfer,
-			options?: ExtractClipboardFilePathsOptions
+			options?: FormatPathForCodeOptions
 		): Thenable<string[] | null>;
 	}
 
@@ -2147,8 +2601,8 @@ declare module 'positron' {
 		 * A language model provider, extends vscode.LanguageModelChatProvider.
 		 */
 		export interface LanguageModelChatProvider<T extends vscode.LanguageModelChatInformation = vscode.LanguageModelChatInformation> {
-			name: string;
-			provider: string;
+			displayName: string;
+			providerId: string;
 			id: string;
 
 			providerName: string;
@@ -2210,11 +2664,34 @@ declare module 'positron' {
 		export function registerChatAgent(agentData: ChatAgentData): Thenable<vscode.Disposable>;
 
 		/**
+		 * Metadata about a language model provider used for configuration.
+		 * Registered during extension activation, independent of sign-in state.
+		 */
+		export interface ProviderMetadata {
+			/**
+			 * Unique identifier for this provider (e.g., 'anthropic-api', 'openai-api', 'copilot').
+			 * Used internally to distinguish between provider implementations.
+			 */
+			id: string;
+			/**
+			 * Display name shown in the UI (e.g., 'Anthropic', 'OpenAI', 'GitHub Copilot').
+			 * Appears in settings, model selection dialogs, and provider lists.
+			 */
+			displayName: string;
+			/**
+			 * Setting name for user configuration in camelCase format (e.g., 'anthropic', 'openAI', 'gitHubCopilot').
+			 * Corresponds to `positron.assistant.provider.<settingName>.enable` in settings.json if visible in Settings UI.
+			 * Positron's Assistant Service automatically reads this from registered providers.
+			 */
+			settingName: string;
+		}
+
+		/**
 		 * Positron Language Model source, used for user configuration of language models.
 		 */
 		export interface LanguageModelSource {
 			type: PositronLanguageModelType;
-			provider: { id: string; displayName: string };
+			provider: ProviderMetadata;
 			supportedOptions: Exclude<{
 				[K in keyof LanguageModelConfig]: undefined extends LanguageModelConfig[K] ? K : never
 			}[keyof LanguageModelConfig], undefined>[];
@@ -2304,12 +2781,21 @@ declare module 'positron' {
 			edits: vscode.TextEdit[];
 		}): void;
 
-		export function getSupportedProviders(): Thenable<string[]>;
-
 		/**
 		 * Get the chat export as a JSON object (IExportableChatData).
 		 */
 		export function getChatExport(): Thenable<object | undefined>;
+
+		/**
+		 * Options for showing the language model configuration modal.
+		 */
+		export interface ShowLanguageModelConfigOptions {
+			/**
+			 * Optional provider ID to pre-select in the dialog.
+			 * If provided and valid, the modal will open with this provider selected.
+			 */
+			preselectedProviderId?: string;
+		}
 
 		/**
 		 * Show a modal dialog for language model configuration.
@@ -2317,7 +2803,17 @@ declare module 'positron' {
 		export function showLanguageModelConfig(
 			sources: LanguageModelSource[],
 			onAction: (config: LanguageModelConfig, action: string) => Thenable<void>,
+			options?: ShowLanguageModelConfigOptions,
 		): Thenable<void>;
+
+		/**
+		 * Registers provider metadata with the core service.
+		 * This allows the core to check provider enable settings without requiring sign-in.
+		 * Should be called during extension activation for all available providers.
+		 *
+		 * @param metadata Provider identification and settings information
+		 */
+		export function registerProviderMetadata(metadata: ProviderMetadata): void;
 
 		/**
 		 * Adds the model to the service's known configurations and notifies its listeners.
@@ -2377,6 +2873,16 @@ declare module 'positron' {
 		export function setCurrentProvider(id: string): Thenable<ChatProvider | undefined>;
 
 		/**
+		 * Gets the list of enabled provider IDs from user configuration.
+		 *
+		 * Reads from individual provider enable settings ('positron.assistant.provider.<name>.enable')
+		 * and the deprecated 'positron.assistant.enabledProviders' array setting for backward compatibility.
+		 *
+		 * @returns A Thenable that resolves to an array of enabled provider IDs
+		 */
+		export function getEnabledProviders(): Thenable<string[]>;
+
+		/**
 		 * Checks if completions are enabled for the given file.
 		 * @param uri The file URI to check if completions are enabled.
 		 * @returns A Thenable that resolves to true if completions should be enabled for the file, false otherwise.
@@ -2422,6 +2928,12 @@ declare module 'positron' {
 			 * to fit without taking too much context.
 			 */
 			allCells?: NotebookCell[];
+
+			/**
+			 * The current state of the runtime session (e.g. 'idle', 'busy', 'restarting').
+			 * Undefined if no runtime session is associated with this notebook.
+			 */
+			runtimeState?: string;
 		}
 
 		/**
@@ -2500,10 +3012,10 @@ declare module 'positron' {
 			lastRunEndTime?: number;
 
 			/**
-			 * The cell document URI.
-			 * This is the URI that should be used for chat editing diffs.
+			 * For markdown cells only: whether the editor is shown (true) or preview is shown (false).
+			 * This property is undefined for code cells.
 			 */
-			cellUri: string;
+			editorShown?: boolean;
 		}
 
 		/**
@@ -2552,6 +3064,13 @@ declare module 'positron' {
 		export function deleteCell(notebookUri: string, cellIndex: number): Thenable<void>;
 
 		/**
+		 * Delete multiple cells from a notebook
+		 * @param notebookUri URI of the notebook
+		 * @param cellIndices Array of cell indices to delete
+		 */
+		export function deleteCells(notebookUri: string, cellIndices: number[]): Thenable<void>;
+
+		/**
 		 * Update the content of a cell in a notebook
 		 * @param notebookUri URI of the notebook
 		 * @param cellIndex Index of the cell to update
@@ -2598,5 +3117,20 @@ declare module 'positron' {
 		 *                 Must be a valid permutation containing each index from 0 to cellCount-1 exactly once.
 		 */
 		export function reorderCells(notebookUri: string, newOrder: number[]): Thenable<void>;
+
+		/**
+		 * Scroll to a cell if it's out of view and auto-follow is enabled.
+		 * Respects the `positron.assistant.notebook.autoFollow` setting.
+		 * @param notebookUri The notebook URI as a string
+		 * @param cellIndex The index of the cell to scroll to
+		 */
+		export function scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Thenable<void>;
+
+		/**
+		 * Clear cell outputs in a notebook.
+		 * @param notebookUri URI of the notebook
+		 * @param cellIndices Optional array of cell indices to clear. If omitted, clears all cells.
+		 */
+		export function clearCellOutputs(notebookUri: string, cellIndices?: number[]): Thenable<void>;
 	}
 }

--- a/tests/integration/consumer-typecheck.test.ts
+++ b/tests/integration/consumer-typecheck.test.ts
@@ -1,30 +1,39 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
 describe('Consumer type-checking (issue #4)', () => {
-  const distDir = path.resolve(__dirname, '../../dist');
-  const vscodeTypesDir = path.resolve(__dirname, '../../node_modules/@types/vscode');
+  const pkgRoot = path.resolve(__dirname, '../..');
+  const vscodeTypesDir = path.resolve(pkgRoot, 'node_modules/@types/vscode');
+  let tarballPath: string;
+
+  beforeAll(() => {
+    const out = execSync('npm pack --pack-destination /tmp 2>&1', {
+      cwd: pkgRoot,
+      encoding: 'utf8',
+    });
+    const filename = out.trim().split('\n').pop()!;
+    tarballPath = path.join('/tmp', filename);
+  });
 
   function createConsumerProject(tsconfig: Record<string, unknown>): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-consumer-'));
 
-    // Simulate an installed package: node_modules/@posit-dev/positron/dist -> our dist
-    const pkgDir = path.join(dir, 'node_modules', '@posit-dev', 'positron');
-    fs.mkdirSync(pkgDir, { recursive: true });
-    fs.symlinkSync(distDir, path.join(pkgDir, 'dist'));
-    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
-      name: '@posit-dev/positron',
-      main: 'dist/index.js',
-      types: 'dist/index.d.ts',
-    }));
+    // Install the packed tarball exactly as a real consumer would
+    execSync(`npm init -y --silent && npm install --no-save ${tarballPath}`, {
+      cwd: dir,
+      stdio: 'pipe',
+    });
 
-    // Provide @types/vscode from our own node_modules
-    const typesDir = path.join(dir, 'node_modules', '@types');
-    fs.mkdirSync(typesDir, { recursive: true });
-    fs.symlinkSync(vscodeTypesDir, path.join(typesDir, 'vscode'));
+    // Ensure @types/vscode is available (may already exist from npm install)
+    const vscodeTarget = path.join(dir, 'node_modules', '@types', 'vscode');
+    if (!fs.existsSync(vscodeTarget)) {
+      const typesDir = path.join(dir, 'node_modules', '@types');
+      fs.mkdirSync(typesDir, { recursive: true });
+      fs.symlinkSync(vscodeTypesDir, vscodeTarget);
+    }
 
     fs.writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
     fs.writeFileSync(path.join(dir, 'index.ts'), [

--- a/tests/integration/consumer-typecheck.test.ts
+++ b/tests/integration/consumer-typecheck.test.ts
@@ -18,7 +18,10 @@ describe('Consumer type-checking (issue #4)', () => {
     tarballPath = path.join('/tmp', filename);
   });
 
-  function createConsumerProject(tsconfig: Record<string, unknown>): string {
+  function createConsumerProject(
+    tsconfig: Record<string, unknown>,
+    packageJsonOverrides?: Record<string, unknown>,
+  ): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-consumer-'));
 
     // Install the packed tarball exactly as a real consumer would
@@ -27,12 +30,18 @@ describe('Consumer type-checking (issue #4)', () => {
       stdio: 'pipe',
     });
 
-    // Ensure @types/vscode is available (may already exist from npm install)
+    if (packageJsonOverrides) {
+      const pkgPath = path.join(dir, 'package.json');
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      Object.assign(pkg, packageJsonOverrides);
+      fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+    }
+
+    // Ensure @types/vscode is available (may already exist from npm install).
+    // Use fs.cpSync instead of symlinks for Windows compatibility.
     const vscodeTarget = path.join(dir, 'node_modules', '@types', 'vscode');
     if (!fs.existsSync(vscodeTarget)) {
-      const typesDir = path.join(dir, 'node_modules', '@types');
-      fs.mkdirSync(typesDir, { recursive: true });
-      fs.symlinkSync(vscodeTypesDir, vscodeTarget);
+      fs.cpSync(vscodeTypesDir, vscodeTarget, { recursive: true });
     }
 
     fs.writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
@@ -82,16 +91,19 @@ describe('Consumer type-checking (issue #4)', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('should compile with node16 module resolution', () => {
-    const dir = createConsumerProject({
-      compilerOptions: {
-        module: 'Node16',
-        moduleResolution: 'Node16',
-        target: 'ES2020',
-        strict: true,
-        skipLibCheck: false,
+  it('should compile with node16 module resolution (ESM)', () => {
+    const dir = createConsumerProject(
+      {
+        compilerOptions: {
+          module: 'Node16',
+          moduleResolution: 'Node16',
+          target: 'ES2020',
+          strict: true,
+          skipLibCheck: false,
+        },
       },
-    });
+      { type: 'module' },
+    );
     const result = tscCheck(dir);
     expect(result.output, 'tsc errors:\n' + result.output).toBe('');
     expect(result.ok).toBe(true);

--- a/tests/integration/consumer-typecheck.test.ts
+++ b/tests/integration/consumer-typecheck.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('Consumer type-checking (issue #4)', () => {
+  const distDir = path.resolve(__dirname, '../../dist');
+  const vscodeTypesDir = path.resolve(__dirname, '../../node_modules/@types/vscode');
+
+  function createConsumerProject(tsconfig: Record<string, unknown>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-consumer-'));
+
+    // Simulate an installed package: node_modules/@posit-dev/positron/dist -> our dist
+    const pkgDir = path.join(dir, 'node_modules', '@posit-dev', 'positron');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.symlinkSync(distDir, path.join(pkgDir, 'dist'));
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+      name: '@posit-dev/positron',
+      main: 'dist/index.js',
+      types: 'dist/index.d.ts',
+    }));
+
+    // Provide @types/vscode from our own node_modules
+    const typesDir = path.join(dir, 'node_modules', '@types');
+    fs.mkdirSync(typesDir, { recursive: true });
+    fs.symlinkSync(vscodeTypesDir, path.join(typesDir, 'vscode'));
+
+    fs.writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
+    fs.writeFileSync(path.join(dir, 'index.ts'), [
+      'import { tryAcquirePositronApi, inPositron } from "@posit-dev/positron";',
+      'const api = tryAcquirePositronApi();',
+      'console.log(api?.version, inPositron());',
+    ].join('\n'));
+
+    return dir;
+  }
+
+  function tscCheck(projectDir: string): { ok: boolean; output: string } {
+    try {
+      execSync('tsc --noEmit', { cwd: projectDir, stdio: 'pipe' });
+      return { ok: true, output: '' };
+    } catch (err: any) {
+      return { ok: false, output: err.stdout?.toString() + err.stderr?.toString() };
+    }
+  }
+
+  it('should compile with skipLibCheck: false (commonjs)', () => {
+    const dir = createConsumerProject({
+      compilerOptions: {
+        module: 'commonjs',
+        target: 'ES2020',
+        strict: true,
+        skipLibCheck: false,
+      },
+    });
+    const result = tscCheck(dir);
+    expect(result.output, 'tsc errors:\n' + result.output).toBe('');
+    expect(result.ok).toBe(true);
+  });
+
+  it('should compile with skipLibCheck: true (commonjs)', () => {
+    const dir = createConsumerProject({
+      compilerOptions: {
+        module: 'commonjs',
+        target: 'ES2020',
+        strict: true,
+        skipLibCheck: true,
+      },
+    });
+    const result = tscCheck(dir);
+    expect(result.output, 'tsc errors:\n' + result.output).toBe('');
+    expect(result.ok).toBe(true);
+  });
+
+  it('should compile with node16 module resolution', () => {
+    const dir = createConsumerProject({
+      compilerOptions: {
+        module: 'Node16',
+        moduleResolution: 'Node16',
+        target: 'ES2020',
+        strict: true,
+        skipLibCheck: false,
+      },
+    });
+    const result = tscCheck(dir);
+    expect(result.output, 'tsc errors:\n' + result.output).toBe('');
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/integration/consumer-typecheck.test.ts
+++ b/tests/integration/consumer-typecheck.test.ts
@@ -11,7 +11,7 @@ describe('Consumer type-checking (issue #4)', () => {
 
   beforeAll(() => {
     const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-pack-'));
-    const out = execSync(`npm pack --pack-destination ${packDir} 2>&1`, {
+    const out = execSync(`npm pack --pack-destination "${packDir}" 2>&1`, {
       cwd: pkgRoot,
       encoding: 'utf8',
     });
@@ -26,7 +26,7 @@ describe('Consumer type-checking (issue #4)', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-consumer-'));
 
     // Install the packed tarball exactly as a real consumer would
-    execSync(`npm init -y --silent && npm install --no-save ${tarballPath}`, {
+    execSync(`npm init -y --silent && npm install --no-save "${tarballPath}"`, {
       cwd: dir,
       stdio: 'pipe',
     });

--- a/tests/integration/consumer-typecheck.test.ts
+++ b/tests/integration/consumer-typecheck.test.ts
@@ -10,12 +10,13 @@ describe('Consumer type-checking (issue #4)', () => {
   let tarballPath: string;
 
   beforeAll(() => {
-    const out = execSync('npm pack --pack-destination /tmp 2>&1', {
+    const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-pack-'));
+    const out = execSync(`npm pack --pack-destination ${packDir} 2>&1`, {
       cwd: pkgRoot,
       encoding: 'utf8',
     });
     const filename = out.trim().split('\n').pop()!;
-    tarballPath = path.join('/tmp', filename);
+    tarballPath = path.join(packDir, filename);
   });
 
   function createConsumerProject(
@@ -41,6 +42,7 @@ describe('Consumer type-checking (issue #4)', () => {
     // Use fs.cpSync instead of symlinks for Windows compatibility.
     const vscodeTarget = path.join(dir, 'node_modules', '@types', 'vscode');
     if (!fs.existsSync(vscodeTarget)) {
+      fs.mkdirSync(path.dirname(vscodeTarget), { recursive: true });
       fs.cpSync(vscodeTypesDir, vscodeTarget, { recursive: true });
     }
 

--- a/tests/unit/strip-proposed-types.test.ts
+++ b/tests/unit/strip-proposed-types.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 
+function getProposedTypeReplacements(): string[] {
+  const buildSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../build.js'),
+    'utf8'
+  );
+  const match = buildSrc.match(
+    /PROPOSED_TYPE_REPLACEMENTS\s*=\s*\[([\s\S]*?)\]/
+  );
+  if (!match) throw new Error('Could not find PROPOSED_TYPE_REPLACEMENTS in build.js');
+  const names = [...match[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+  if (names.length === 0) throw new Error('PROPOSED_TYPE_REPLACEMENTS is empty');
+  return names;
+}
+
 describe('Strip proposed vscode-dts types (issue #4)', () => {
   const distPositronDts = fs.readFileSync(
     path.resolve(__dirname, '../../dist/positron.d.ts'),
@@ -16,14 +30,9 @@ describe('Strip proposed vscode-dts types (issue #4)', () => {
   });
 
   it('should not reference proposed-only types', () => {
-    const proposedTypes = [
-      'vscode.LanguageModelChatInformation',
-      'vscode.ProvideLanguageModelChatResponseOptions',
-      'vscode.LanguageModelResponsePart2',
-      'vscode.LanguageModelChatMessage2',
-    ];
+    const proposedTypes = getProposedTypeReplacements();
     for (const typeName of proposedTypes) {
-      expect(distPositronDts).not.toContain(typeName);
+      expect(distPositronDts).not.toContain(`vscode.${typeName}`);
     }
   });
 

--- a/tests/unit/strip-proposed-types.test.ts
+++ b/tests/unit/strip-proposed-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Strip proposed vscode-dts types (issue #4)', () => {
+  const distPositronDts = fs.readFileSync(
+    path.resolve(__dirname, '../../dist/positron.d.ts'),
+    'utf8'
+  );
+
+  it('should not contain vscode-dts reference directives', () => {
+    const refs = distPositronDts.match(
+      /\/\/\/\s*<reference\s+path=["'][^"']*vscode-dts\/[^"']*["']\s*\/>/g
+    );
+    expect(refs).toBeNull();
+  });
+
+  it('should not reference proposed-only types', () => {
+    const proposedTypes = [
+      'vscode.LanguageModelChatInformation',
+      'vscode.ProvideLanguageModelChatResponseOptions',
+      'vscode.LanguageModelResponsePart2',
+      'vscode.LanguageModelChatMessage2',
+    ];
+    for (const typeName of proposedTypes) {
+      expect(distPositronDts).not.toContain(typeName);
+    }
+  });
+
+  it('should still declare the positron module', () => {
+    expect(distPositronDts).toContain("declare module 'positron'");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a build step that strips `/// <reference path="...vscode-dts/...">` directives from `dist/positron.d.ts` and replaces 4 proposed-only types with `any`, making the published package self-contained
- Adds integration tests that `npm pack` the package, install it in a temp project, and run `tsc --noEmit` under three configurations (commonjs + skipLibCheck false, commonjs + skipLibCheck true, Node16 ESM)
- Adds unit tests that verify the strip logic against the built output, deriving the expected type list from `build.js`
- Restores the `@types/vscode` peer dependency to `^1.74.0` (no version coupling)

Closes #4. 

## Test plan

- [x] All 35 tests pass (29 existing + 3 integration + 3 strip-proposed-types)
- [x] Integration test reproduces the exact issue #4 errors when run against an unpatched build
- [x] Verified against positron-extension-demo, positron-extension-template, and positron-api-showcase with `skipLibCheck: false`
- [x] Verified with the minimal repro from issue #4