### PR TITLE
ci: use positron-bot app to draft and push releases 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,12 @@ jobs:
           # pull requests" -- that setting only restricts GITHUB_TOKEN. Merging
           # the PR then satisfies the branch ruleset, so no bypass is needed.
           token: ${{ steps.app-token.outputs.token }}
+          # Fetch all branches so origin/main exists locally. The release step's
+          # `gh pr merge --delete-branch` switches HEAD to the default branch
+          # after merging, and the tag step checks out and resets to
+          # origin/main; both need main present, which a shallow single-branch
+          # checkout (the default) does not provide.
+          fetch-depth: 0
 
       - name: Shallow clone Positron repo
         run: |
@@ -139,8 +145,8 @@ jobs:
       - name: Configure git
         if: ${{ steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true' }}
         run: |
-          git config user.name "positron-bot[bot]"
-          git config user.email "173392469+positron-bot[bot]@users.noreply.github.com"
+          git config user.name "positron-projects[bot]"
+          git config user.email "210906922+positron-projects[bot]@users.noreply.github.com"
 
       - name: Open release PR, merge, and tag
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       # Resolve inputs - repository_dispatch uses payload, workflow_dispatch uses inputs
@@ -124,18 +125,39 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit changes
-        if: ${{ steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true' }}
-        run: |
-          git add package.json package-lock.json README.md
-          git commit -m "Release v${{ steps.bump_version.outputs.version }}"
-          git tag "v${{ steps.bump_version.outputs.version }}"
-
-      - name: Push changes
+      - name: Open release PR, merge, and tag
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}
+        env:
+          VERSION: ${{ steps.bump_version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin HEAD
-          git push origin "v${{ steps.bump_version.outputs.version }}"
+          BRANCH="release/v${VERSION}"
+
+          # main requires changes to go through a PR, so commit to a release
+          # branch and merge via PR instead of pushing to main directly.
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json README.md
+          git commit -m "Release v${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release v${VERSION}" \
+            --body "Automated release of @posit-dev/positron v${VERSION}."
+
+          # Immediate squash merge. Requires main to have no required approvals
+          # and no required status checks; otherwise this fails here (by design)
+          # rather than leaving a half-finished release.
+          gh pr merge "$BRANCH" --squash --delete-branch
+
+          # Tag the merged commit on main. Tags aren't covered by the branch
+          # ruleset, so this push is allowed.
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Publish to npm
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
-          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          # positron-bot is managed in rstudio/github-iac as the app
+          # "positron-projects"; its credentials are distributed as the Actions
+          # secrets POSITRON_PROJECTS_APP_ID / POSITRON_PROJECTS_PEM.
+          app-id: ${{ secrets.POSITRON_PROJECTS_APP_ID }}
+          private-key: ${{ secrets.POSITRON_PROJECTS_PEM }}
 
       - name: Checkout this repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,22 @@ jobs:
       FORCE: ${{ inputs.force || false }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+
       - name: Checkout this repository
         uses: actions/checkout@v4
+        with:
+          # Use the positron-bot App token so the release PR is opened and
+          # merged by the App identity. A GitHub App token can create PRs even
+          # though the org disables "Allow GitHub Actions to create and approve
+          # pull requests" -- that setting only restricts GITHUB_TOKEN. Merging
+          # the PR then satisfies the branch ruleset, so no bypass is needed.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Shallow clone Positron repo
         run: |
@@ -122,14 +136,14 @@ jobs:
       - name: Configure git
         if: ${{ steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true' }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "positron-bot[bot]"
+          git config user.email "173392469+positron-bot[bot]@users.noreply.github.com"
 
       - name: Open release PR, merge, and tag
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}
         env:
           VERSION: ${{ steps.bump_version.outputs.version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="release/v${VERSION}"
 
@@ -147,8 +161,14 @@ jobs:
             --body "Automated release of @posit-dev/positron v${VERSION}."
 
           # Immediate squash merge. Requires main to have no required approvals
-          # and no required status checks; otherwise this fails here (by design)
-          # rather than leaving a half-finished release.
+          # (positron-bot can't approve its own PR) and no required status
+          # checks (this merges right away, before any check could finish);
+          # otherwise it fails here by design rather than half-releasing.
+          #
+          # If required checks are added later: this PR is opened by a GitHub
+          # App (not GITHUB_TOKEN), so check workflows DO trigger on it. Switch
+          # to `--auto --squash` and move publish/tag into a second workflow
+          # keyed on the merge to main, since the merge then becomes async.
           gh pr merge "$BRANCH" --squash --delete-branch
 
           # Tag the merged commit on main. Tags aren't covered by the branch


### PR DESCRIPTION
Fixes the Release workflow, which was failing at the push step. The workflow bumped the package version, committed it, then ran git push origin HEAD directly to main — but main is protected by a repository ruleset ("Changes must be made through a pull request"), so the push (and the whole release) was rejected.

This routes the release commit through a PR instead, using the org's positron-bot GitHub App to open and squash-merge it.

Changes:

- Mint a positron-bot App token (`actions/create-github-app-token`) from the already-scoped `vars.POSITRON_BOT_APP_ID` + `secrets.POSITRON_BOT_PRIVATE_KEY`, and check out with it.
- Add pull-requests: write permission; commit as `positron-bot[bot]`.
- Commit the version bump + README update to a `release/vX.Y.Z branch`, open a PR, squash-merge it, then tag the merged commit on main and push the tag (tags aren't branch-protected). npm publish + GitHub release unchanged.

Prerequisites before this runs green

- [x] POSITRON_BOT_PRIVATE_KEY made available to this repo (org-scoped, or added as a repo secret). POSITRON_BOT_APP_ID is already scoped here.
- [X] positron-bot installed on positron-api-pkg with Contents: write + Pull requests: write.
- [X] main has no required approvals or status checks — the immediate squash-merge needs both absent (positron-bot can't approve its own PR; a required check wouldn't have finished at merge time). If either is added later, switch to --auto + a split publish workflow (flagged in a code comment).