### PR TITLE
ci: switch npm publish to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # required for npm trusted publishing (OIDC)
 
     env:
       # Resolve inputs - repository_dispatch uses payload, workflow_dispatch uses inputs
@@ -101,7 +102,9 @@ jobs:
         if: ${{ steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true' }}
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # npm trusted publishing (OIDC) requires Node >=22.14.0 and npm
+          # >=11.5.1; the npm upgrade happens just before the publish step.
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -183,11 +186,15 @@ jobs:
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
+      - name: Upgrade npm for trusted publishing
+        if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Publishes via npm trusted publishing (OIDC) using the id-token
+        # permission above -- no NPM_TOKEN secret needed.
+        run: npm publish --access public --provenance
 
       - name: Create GitHub Release
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,9 +192,7 @@ jobs:
 
       - name: Publish to npm
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}
-        # Publishes via npm trusted publishing (OIDC) using the id-token
-        # permission above -- no NPM_TOKEN secret needed.
-        run: npm publish --access public --provenance
+        run: npm publish
 
       - name: Create GitHub Release
         if: ${{ (steps.check_version.outputs.already_released == 'false' || env.FORCE == 'true') && env.DRY_RUN == 'false' }}


### PR DESCRIPTION
The NPM API token expired 😩, so the 0.2.6 release had to be finished by hand (just the running of `npm publish`, all other pieces were green). We should just move to trusted publishing, so we don't have to mess with API tokens at all. I set everything up on the package side https://www.npmjs.com/package/@posit-dev/positron, now just need to make sure the CI matches.

- Add id-token: write permission for OIDC
- Bump Node 20 -> 22 (trusted publishing requires Node >=22.14.0)
- Upgrade npm to latest before publish (requires npm >=11.5.1)
- Drop NODE_AUTH_TOKEN/NPM_TOKEN in favor of OIDC auth